### PR TITLE
Keep line endings in Sort, and fix schema in Validate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# PlexAniSync files
+custom_mappings_schema.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 jsonschema==4.6.1
 ruamel.yaml==0.17.21
+requests==2.31.0

--- a/sort.py
+++ b/sort.py
@@ -13,7 +13,7 @@ yaml.indent(sequence=4, offset=2)
 yaml.width = 1024
 
 for file in glob.glob("*.yaml"):
-    with open(file, 'r+', encoding='utf-8') as f:
+    with open(file, 'r+b') as f:
         file_mappings = yaml.load(f)
         file_mappings["entries"].sort(key=lambda entry: entry["title"].lower())
         # Jump to beginning of file and overwrite with sorted entries

--- a/validate.py
+++ b/validate.py
@@ -5,13 +5,31 @@ import sys
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError
 from ruamel.yaml import YAML
+import requests
 
 logger = logging.getLogger("PlexAniSync")
 yaml = YAML(typ='safe')
 SUCCESS = True
+schema_url = "https://raw.githubusercontent.com/RickDB/PlexAniSync/master/custom_mappings_schema.json"
+local_schema_path = './custom_mappings_schema.json'
 
-with open('./custom_mappings_schema.json', 'r', encoding='utf-8') as f:
-    schema = json.load(f)
+# Try to load the schema from the local file
+try:
+    with open(local_schema_path, 'r', encoding='utf-8') as f:
+        schema = json.load(f)
+except FileNotFoundError:
+    # If the local file doesn't exist, fetch it from the remote URL
+    try:
+        response = requests.get(schema_url)
+        response.raise_for_status()
+        schema = response.json()
+        
+        # Save the fetched schema locally
+        with open(local_schema_path, 'w', encoding='utf-8') as f:
+            json.dump(schema, f, indent=4)
+    except requests.RequestException as e:
+        logger.error(f"Failed to fetch schema from {schema_url}: {e}")
+        sys.exit(1)
 
 for file in glob.glob("*.yaml"):
     # Create a Data object


### PR DESCRIPTION
This keeps the line-endings in `Sort.py`, the project has no gain in trying to change the line-endings, and only causes more issues than it's worth. (Changes here also found and fixed 4f09a619697c2d5b99e07c2ca6f6a2cf27f768ca for me)

For `Validate.py` it will now fetch the schema from GitHub if it doesn't exist locally, and then save it.
Not sure if there's a better way to this, it also doesn't check for changes to the source