### PR TITLE
Fix Oshi no Ko TMDB mapping

### DIFF
--- a/series-tmdb.en.yaml
+++ b/series-tmdb.en.yaml
@@ -2040,6 +2040,7 @@ entries:
         anilist-id: 150672
       - season: 2
         anilist-id: 166531
+        start: 12
 
   - title: "Overlord"
     guid: plex://show/5d9c080def619b002047c6f0

--- a/series-tmdb.en.yaml
+++ b/series-tmdb.en.yaml
@@ -2038,7 +2038,7 @@ entries:
     seasons:
       - season: 1
         anilist-id: 150672
-      - season: 2
+      - season: 1
         anilist-id: 166531
         start: 12
 


### PR DESCRIPTION
Oshi no Ko season 2 is mapped into season 1 in TMDB, this properly sets the start parameter