### PR TITLE
Update series-tvdb.en.yaml

### DIFF
--- a/series-tvdb.en.yaml
+++ b/series-tvdb.en.yaml
@@ -3800,3 +3800,16 @@ entries:
         anilist-id: 103900
       - season: 2
         anilist-id: 110229
+
+  - title: "Urusei Yatsura (2022)"
+    guid: plex://show/61d17a3a7bbf0f7c110ea567
+    # imdb: https://www.imdb.com/title/tt16764368/
+    # tmdb: https://www.themoviedb.org/tv/154524
+    # tvdb: https://www.thetvdb.com/dereferrer/series/414096
+    seasons:
+      - season: 1
+      # Listed on HiDive as Season 1 and 2
+        anilist-id: 143277
+      - season: 2
+      # Listed on HiDive as Season 3 and 4
+        anilist-id: 155645

--- a/series-tvdb.en.yaml
+++ b/series-tvdb.en.yaml
@@ -3417,6 +3417,7 @@ entries:
         anilist-id: 591
       - season: 2
         anilist-id: 886
+        
   - title: "All Purpose Cultural Cat Girl Nuku Nuku (1998)"
     guid: plex://show/5d9c0807705e7a001e6d066c
     # imdb: https://www.imdb.com/title/tt0414813/
@@ -3426,6 +3427,7 @@ entries:
         anilist-id: 375
       - season: 2
         anilist-id: 374
+        
   - title: "Burn-Up W"
     guid: plex://show/5d9c083de98e47001eb0afaf
     # imdb: https://www.imdb.com/title/tt0158533/
@@ -3448,6 +3450,7 @@ entries:
       # tmdb: https://www.themoviedb.org/tv/8907
       # tvdb: https://www.thetvdb.com/dereferrer/series/79048
         anilist-id: 693
+        
   - title: "Charger Girl Juden Chan"
     guid: plex://show/5d9c084602391c001f5853f3
     # imdb: https://www.imdb.com/title/tt1458514/
@@ -3456,6 +3459,7 @@ entries:
     seasons:
       - season: 1
         anilist-id: 5973
+        
   - title: "Cross Ange: Rondo of Angels and Dragons"
     guid: plex://show/5d9c0849ef619b002047e29f
     # imdb: https://www.imdb.com/title/tt3957232/
@@ -3464,6 +3468,7 @@ entries:
     seasons:
       - season: 1
         anilist-id: 20806
+        
   - title: "Divergence Eve"
     guid: plex://show/61b10427ebb196850a1ff78d
     # imdb: https://www.imdb.com/title/tt0972633/
@@ -3474,6 +3479,7 @@ entries:
         anilist-id: 294
       - season: 2
         anilist-id: 295
+        
   - title: "Eureka Seven"
     guid: plex://show/5d9c081b4eefaa001f5d5e0e
     # imdb: https://www.imdb.com/title/tt0765491/
@@ -3484,6 +3490,7 @@ entries:
         anilist-id: 237
       - season: 2
         anilist-id: 12471
+        
   - title: "Freezing"
     guid: plex://show/5d9c08527d06d9001ffd1852
     # imdb: https://www.imdb.com/title/tt1909463/
@@ -3494,6 +3501,7 @@ entries:
         anilist-id: 9367
       - season: 2
         anilist-id: 18001
+        
   - title: "Girls Bravo"
     guid: plex://show/5d9c08680aaccd001f8efd6c
     # imdb: https://www.imdb.com/title/tt0807675/
@@ -3504,6 +3512,7 @@ entries:
         anilist-id: 241
       - season: 2
         anilist-id: 487
+        
   - title: "Grenadier"
     guid: plex://show/5d9c07f6705e7a001e6cda24
     # imdb: https://www.imdb.com/title/tt0985984/
@@ -3514,6 +3523,7 @@ entries:
     seasons:
       - season: 1 
         anilist-id: 297
+        
   - title: ".hack//SIGN"
     guid: plex://show/5d9c07f9e98e47001eb04432
     # imdb: https://www.imdb.com/title/tt0361140/
@@ -3526,6 +3536,7 @@ entries:
         anilist-id: 298
       - season: 3
         anilist-id: 873
+        
   - title: "Haganai: I Don't Have Many Friends"
     guid: plex://show/5d9c083b3c3f87001f34abac
     # imdb: https://www.imdb.com/title/tt2645500/
@@ -3536,6 +3547,7 @@ entries:
         anilist-id: 10719
       - season: 2
         anilist-id: 14967
+        
   - title: "Ikki Tousen"
     guid: plex://show/5d9c084d08fddd001f296e53
     # imdb: https://www.imdb.com/title/tt0486171/
@@ -3550,6 +3562,7 @@ entries:
         anilist-id: 4196
       - season: 4
         anilist-id: 7580
+        
   - title: "Is This a Zombie?"
     guid: plex://show/5d9c0852170e24001f2a9908
     # imdb: https://www.imdb.com/title/tt1780262/
@@ -3560,6 +3573,7 @@ entries:
         anilist-id: 8841
       - season: 2
         anilist-id: 10790
+        
   - title: "The Melancholy of Haruhi Suzumiya"
     guid: plex://show/5d9c0827705e7a001e6d4307
     # imdb: https://www.imdb.com/title/tt0816407/
@@ -3572,6 +3586,7 @@ entries:
       - season: 2
         anilist-id: 4382
         start: 15
+        
   - title: "Queen's Blade"
     guid: plex://show/5d9c084fba6eb9001fba0a0b
     # imdb: https://www.imdb.com/title/tt1407599/
@@ -3593,6 +3608,7 @@ entries:
       # tmdb: https://www.themoviedb.org/tv/254227
       # tvdb: https://www.thetvdb.com/dereferrer/series/438850
         anilist-id: 11859
+        
   - title: "Ranma ½"
     guid: plex://show/5d9c0833ba6eb9001fb9e579
     # imdb: https://www.imdb.com/title/tt0096686/
@@ -3619,6 +3635,7 @@ entries:
       - season: 7
         anilist-id: 149939
         start: 118
+        
   - title: "Samurai Girls"
     guid: plex://show/5d9c0838ec357c001f9aabcc
     # imdb: https://www.imdb.com/title/tt2074011/
@@ -3631,6 +3648,7 @@ entries:
         anilist-id: 8277
       - season: 2
         anilist-id: 15377
+        
   - title: "School Rumble"
     guid: plex://show/5d9c08233c3f87001f3485da
     # imdb: https://www.imdb.com/title/tt0878037/
@@ -3641,6 +3659,7 @@ entries:
         anilist-id: 24
       - season: 2
         anilist-id: 846
+        
   - title: "Senran Kagura: Ninja Flash"
     guid: plex://show/5d9c08293c3f87001f3490f1
     # imdb: https://www.imdb.com/title/tt2360110/
@@ -3651,6 +3670,7 @@ entries:
         anilist-id: 15119
       - season: 2
         anilist-id: 102822
+        
   - title: "The Testament of Sister New Devil"
     guid: plex://show/5d9c080dffd9ef001e98b82a
     # imdb: https://www.imdb.com/title/tt4219258/
@@ -3661,6 +3681,7 @@ entries:
         anilist-id: 20678
       - season: 2      
         anilist-id: 21110
+        
   - title: "To LOVE-Ru"
     guid: plex://show/5d9c08356c3e37001ecd5676
     # imdb: https://www.imdb.com/title/tt1216222/
@@ -3687,6 +3708,7 @@ entries:
       # tmdb: https://www.themoviedb.org/tv/34742-to-love-ru/season/4
       # tvdb: https://www.thetvdb.com/series/to-love-ru/seasons/official/4
         anilist-id: 20995
+        
   - title: "VanDread"
     guid: plex://show/5d9c07f9e98e47001eb0443d
     # imdb: https://www.imdb.com/title/tt0309226/
@@ -3707,6 +3729,7 @@ entries:
         anilist-id: 154412
       - season: 2
         anilist-id: 166477
+        
   - title: "The Fruit of Grisaia"
     guid: plex://show/5d9c0849ffd9ef001e990fe3
     # imdb: https://www.imdb.com/title/tt3909210/
@@ -3717,6 +3740,7 @@ entries:
         anilist-id: 17729
       - season: 2
         anilist-id: 21006
+        
   - title: "I Tried Asking While Kowtowing"
     guid: plex://show/5f262b806880010040abc2cb
     # imdb: https://www.imdb.com/title/tt12803708/
@@ -3725,6 +3749,7 @@ entries:
     seasons:
       - season: 1
         anilist-id: 122137
+        
   - title: "Jubei-chan the Ninja Girl: Secret of the Lovely Eyepatch"
     guid: plex://show/61b16922bb2f1261dee5e5a0
     # imdb: https://www.imdb.com/title/tt0192903/
@@ -3737,6 +3762,7 @@ entries:
         anilist-id: 635
       - season: 2
         anilist-id: 636
+        
   - title: "Nisekoi"
     guid: plex://show/5d9c086702391c001f5886bd
     # imdb: https://www.imdb.com/title/tt3115338/
@@ -3749,6 +3775,7 @@ entries:
         anilist-id: 18897
       - season: 2
         anilist-id: 20876
+        
   - title: "Saekano: How to Raise a Boring Girlfriend"
     guid: plex://show/5d9c08142df347001e3aa27f
     # imdb: https://www.imdb.com/title/tt3612626/
@@ -3759,6 +3786,7 @@ entries:
         anilist-id: 20657
       - season: 2
         anilist-id: 21180
+        
   - title: "We Never Learn"
     guid: plex://show/5d9c091808fddd001f2a7942
     # imdb: https://www.imdb.com/title/tt9883676/

--- a/series-tvdb.en.yaml
+++ b/series-tvdb.en.yaml
@@ -3800,16 +3800,3 @@ entries:
         anilist-id: 103900
       - season: 2
         anilist-id: 110229
-
-  - title: "Urusei Yatsura (2022)"
-    guid: plex://show/61d17a3a7bbf0f7c110ea567
-    # imdb: https://www.imdb.com/title/tt16764368/
-    # tmdb: https://www.themoviedb.org/tv/154524
-    # tvdb: https://www.thetvdb.com/dereferrer/series/414096
-    seasons:
-      - season: 1
-      # Listed on HiDive as Season 1 and 2
-        anilist-id: 143277
-      - season: 2
-      # Listed on HiDive as Season 3 and 4
-        anilist-id: 155645

--- a/series-tvdb.en.yaml
+++ b/series-tvdb.en.yaml
@@ -3406,3 +3406,368 @@ entries:
     seasons:
       - season: 1
         anilist-id: 175198
+
+  - title: "Ah! My Buddha"
+    guid: plex://show/5d9c082c2df347001e3acc70
+    # imdb: https://www.imdb.com/title/tt0978531/
+    # tmdb: https://www.themoviedb.org/tv/42786
+    # tvdb: https://www.thetvdb.com/dereferrer/series/80075
+    seasons:
+      - season: 1
+        anilist-id: 591
+      - season: 2
+        anilist-id: 886
+  - title: "All Purpose Cultural Cat Girl Nuku Nuku (1998)"
+    guid: plex://show/5d9c0807705e7a001e6d066c
+    # imdb: https://www.imdb.com/title/tt0414813/
+    # tvdb: https://www.thetvdb.com/dereferrer/series/351514
+    seasons:
+      - season: 1
+        anilist-id: 375
+      - season: 2
+        anilist-id: 374
+  - title: "Burn-Up W"
+    guid: plex://show/5d9c083de98e47001eb0afaf
+    # imdb: https://www.imdb.com/title/tt0158533/
+    # tmdb: https://www.themoviedb.org/tv/43416
+    # tvdb: https://www.thetvdb.com/dereferrer/series/140391
+    seasons:
+      - season: 1
+        anilist-id: 769
+      - season: 2
+      # season title: "Burn Up Excess"
+      # guid: plex://show/5d9c083de98e47001eb0afce
+      # imdb: https://www.imdb.com/title/tt0346220/
+      # tmdb: https://www.themoviedb.org/tv/43417
+      # tvdb: https://www.thetvdb.com/dereferrer/series/73526
+        anilist-id: 370
+      - season: 3
+      # season title: "Burn Up Scramble"
+      # guid: plex://show/61b33e47be1bb6b8100debb9
+      # imdb: https://www.imdb.com/title/tt4372186/
+      # tmdb: https://www.themoviedb.org/tv/8907
+      # tvdb: https://www.thetvdb.com/dereferrer/series/79048
+        anilist-id: 693
+  - title: "Charger Girl Juden Chan"
+    guid: plex://show/5d9c084602391c001f5853f3
+    # imdb: https://www.imdb.com/title/tt1458514/
+    # tmdb: https://www.themoviedb.org/tv/36984
+    # tvdb: https://www.thetvdb.com/dereferrer/series/103291
+    seasons:
+      - season: 1
+        anilist-id: 5973
+  - title: "Cross Ange: Rondo of Angels and Dragons"
+    guid: plex://show/5d9c0849ef619b002047e29f
+    # imdb: https://www.imdb.com/title/tt3957232/
+    # tmdb: https://www.themoviedb.org/tv/61425
+    # tvdb: https://www.thetvdb.com/dereferrer/series/284402
+    seasons:
+      - season: 1
+        anilist-id: 20806
+  - title: "Divergence Eve"
+    guid: plex://show/61b10427ebb196850a1ff78d
+    # imdb: https://www.imdb.com/title/tt0972633/
+    # tmdb: https://www.themoviedb.org/tv/12352
+    # tvdb: https://www.thetvdb.com/dereferrer/series/79161
+    seasons:
+      - season: 1
+        anilist-id: 294
+      - season: 2
+        anilist-id: 295
+  - title: "Eureka Seven"
+    guid: plex://show/5d9c081b4eefaa001f5d5e0e
+    # imdb: https://www.imdb.com/title/tt0765491/
+    # tmdb: https://www.themoviedb.org/tv/889
+    # tvdb: https://www.thetvdb.com/dereferrer/series/79360
+    seasons:
+      - season: 1 
+        anilist-id: 237
+      - season: 2
+        anilist-id: 12471
+  - title: "Freezing"
+    guid: plex://show/5d9c08527d06d9001ffd1852
+    # imdb: https://www.imdb.com/title/tt1909463/
+    # tmdb: https://www.themoviedb.org/tv/38441
+    # tvdb: https://www.thetvdb.com/dereferrer/series/219701
+    seasons:
+      - season: 1 
+        anilist-id: 9367
+      - season: 2
+        anilist-id: 18001
+  - title: "Girls Bravo"
+    guid: plex://show/5d9c08680aaccd001f8efd6c
+    # imdb: https://www.imdb.com/title/tt0807675/
+    # tmdb: https://www.themoviedb.org/tv/34793
+    # tvdb: https://www.thetvdb.com/dereferrer/series/78856
+    seasons:
+      - season: 1 
+        anilist-id: 241
+      - season: 2
+        anilist-id: 487
+  - title: "Grenadier"
+    guid: plex://show/5d9c07f6705e7a001e6cda24
+    # imdb: https://www.imdb.com/title/tt0985984/
+    # tmdb: https://www.themoviedb.org/tv/24722
+    # tvdb: https://www.thetvdb.com/dereferrer/series/79132
+    synonyms:
+     - 'Grenadier: The Beautiful Warrior'
+    seasons:
+      - season: 1 
+        anilist-id: 297
+  - title: ".hack//SIGN"
+    guid: plex://show/5d9c07f9e98e47001eb04432
+    # imdb: https://www.imdb.com/title/tt0361140/
+    # tmdb: https://www.themoviedb.org/tv/8864
+    # tvdb: https://www.thetvdb.com/dereferrer/series/79099
+    seasons:
+      - season: 1
+        anilist-id: 48
+      - season: 2
+        anilist-id: 298
+      - season: 3
+        anilist-id: 873
+  - title: "Haganai: I Don't Have Many Friends"
+    guid: plex://show/5d9c083b3c3f87001f34abac
+    # imdb: https://www.imdb.com/title/tt2645500/
+    # tmdb: https://www.themoviedb.org/tv/60730
+    # tvdb: https://www.thetvdb.com/dereferrer/series/251908
+    seasons:
+      - season: 1
+        anilist-id: 10719
+      - season: 2
+        anilist-id: 14967
+  - title: "Ikki Tousen"
+    guid: plex://show/5d9c084d08fddd001f296e53
+    # imdb: https://www.imdb.com/title/tt0486171/
+    # tmdb: https://www.themoviedb.org/tv/37584
+    # tvdb: https://www.thetvdb.com/dereferrer/series/80158
+    seasons:
+      - season: 1
+        anilist-id: 257
+      - season: 2
+        anilist-id: 1956
+      - season: 3
+        anilist-id: 4196
+      - season: 4
+        anilist-id: 7580
+  - title: "Is This a Zombie?"
+    guid: plex://show/5d9c0852170e24001f2a9908
+    # imdb: https://www.imdb.com/title/tt1780262/
+    # tmdb: https://www.themoviedb.org/tv/38420
+    # tvdb: https://www.thetvdb.com/dereferrer/series/220571
+    seasons:
+      - season: 1
+        anilist-id: 8841
+      - season: 2
+        anilist-id: 10790
+  - title: "The Melancholy of Haruhi Suzumiya"
+    guid: plex://show/5d9c0827705e7a001e6d4307
+    # imdb: https://www.imdb.com/title/tt0816407/
+    # tmdb: https://www.themoviedb.org/tv/42511
+    # tvdb: https://www.thetvdb.com/dereferrer/series/79414
+    seasons:
+      - season: 1
+        anilist-id: 4382
+        start: 1
+      - season: 2
+        anilist-id: 4382
+        start: 15
+  - title: "Queen's Blade"
+    guid: plex://show/5d9c084fba6eb9001fba0a0b
+    # imdb: https://www.imdb.com/title/tt1407599/
+    # tmdb: https://www.themoviedb.org/tv/45502
+    # tvdb: https://www.thetvdb.com/dereferrer/series/87491
+    seasons:
+      - season: 1
+        anilist-id: 4719
+      - season: 2
+      # season title: "Queen's Blade 2: The Evil Eye"
+      # guid: plex://show/64bc86919d8f14501b996f3c
+      # imdb: https://www.imdb.com/title/tt1515985/
+      # tvdb: https://www.thetvdb.com/dereferrer/series/437473
+        anilist-id: 6633
+      - season: 3
+      # season title: "Queen's Blade: Rebellion"
+      # guid: plex://show/64ee50ba8ef4fa9d549f4e22
+      # imdb: https://www.imdb.com/title/tt3297074/
+      # tmdb: https://www.themoviedb.org/tv/254227
+      # tvdb: https://www.thetvdb.com/dereferrer/series/438850
+        anilist-id: 11859
+  - title: "Ranma ½"
+    guid: plex://show/5d9c0833ba6eb9001fb9e579
+    # imdb: https://www.imdb.com/title/tt0096686/
+    # tmdb: https://www.themoviedb.org/tv/57706
+    # tvdb: https://www.thetvdb.com/dereferrer/series/76932
+    seasons:
+      - season: 1
+        anilist-id: 210
+      - season: 2
+        anilist-id: 149939
+        start: 1
+      - season: 3
+        anilist-id: 149939
+        start: 23
+      - season: 4
+        anilist-id: 149939
+        start: 46
+      - season: 5
+        anilist-id: 149939
+        start: 70
+      - season: 6
+        anilist-id: 149939
+        start: 94
+      - season: 7
+        anilist-id: 149939
+        start: 118
+  - title: "Samurai Girls"
+    guid: plex://show/5d9c0838ec357c001f9aabcc
+    # imdb: https://www.imdb.com/title/tt2074011/
+    # tmdb: https://www.themoviedb.org/tv/46440
+    # tvdb: https://www.thetvdb.com/dereferrer/series/186911
+    synonyms:
+     - 'Hyakka Ryouran: Samurai Girls'
+    seasons:
+      - season: 1
+        anilist-id: 8277
+      - season: 2
+        anilist-id: 15377
+  - title: "School Rumble"
+    guid: plex://show/5d9c08233c3f87001f3485da
+    # imdb: https://www.imdb.com/title/tt0878037/
+    # tmdb: https://www.themoviedb.org/tv/31665
+    # tvdb: https://www.thetvdb.com/dereferrer/series/79194
+    seasons:
+      - season: 1
+        anilist-id: 24
+      - season: 2
+        anilist-id: 846
+  - title: "Senran Kagura: Ninja Flash"
+    guid: plex://show/5d9c08293c3f87001f3490f1
+    # imdb: https://www.imdb.com/title/tt2360110/
+    # tmdb: https://www.themoviedb.org/tv/46065
+    # tvdb: https://www.thetvdb.com/dereferrer/series/264053
+    seasons:
+      - season: 1
+        anilist-id: 15119
+      - season: 2
+        anilist-id: 102822
+  - title: "The Testament of Sister New Devil"
+    guid: plex://show/5d9c080dffd9ef001e98b82a
+    # imdb: https://www.imdb.com/title/tt4219258/
+    # tmdb: https://www.themoviedb.org/tv/64163
+    # tvdb: https://www.thetvdb.com/dereferrer/series/284719
+    seasons:
+      - season: 1
+        anilist-id: 20678
+      - season: 2      
+        anilist-id: 21110
+  - title: "To LOVE-Ru"
+    guid: plex://show/5d9c08356c3e37001ecd5676
+    # imdb: https://www.imdb.com/title/tt1216222/
+    # tmdb: https://www.themoviedb.org/tv/34742
+    # tvdb: https://www.thetvdb.com/dereferrer/series/81831
+    seasons:
+      - season: 1
+        anilist-id: 3455
+      - season: 2
+      # season title: "Motto To Love-Ru"
+      # imdb: https://www.imdb.com/title/tt1216222/episodes/?season=2
+      # tmdb: https://www.themoviedb.org/tv/34742-to-love-ru/season/2
+      # tvdb: https://www.thetvdb.com/series/to-love-ru/seasons/official/2
+        anilist-id: 9181
+      - season: 3
+      # season title: "To Love-Ru Darkness"
+      # imdb: https://www.imdb.com/title/tt2341806
+      # tmdb: https://www.themoviedb.org/tv/34742-to-love-ru/season/3
+      # tvdb: https://www.thetvdb.com/series/to-love-ru/seasons/official/3
+        anilist-id: 13663
+      - season: 4
+      # season title: "To Love-Ru Darkness 2nd"
+      # imdb: https://www.imdb.com/title/tt2341806/episodes/?season=2
+      # tmdb: https://www.themoviedb.org/tv/34742-to-love-ru/season/4
+      # tvdb: https://www.thetvdb.com/series/to-love-ru/seasons/official/4
+        anilist-id: 20995
+  - title: "VanDread"
+    guid: plex://show/5d9c07f9e98e47001eb0443d
+    # imdb: https://www.imdb.com/title/tt0309226/
+    # tmdb: https://www.themoviedb.org/tv/8863
+    # tvdb: https://www.thetvdb.com/dereferrer/series/71744
+    seasons:
+      - season: 1
+        anilist-id: 180
+      - season: 2
+        anilist-id: 181
+  - title: "The Café Terrace and Its Goddesses"
+    guid: plex://show/631a4e7b302708c9f85bd3dd
+    # imdb: https://www.imdb.com/title/tt22087138/
+    # tmdb: https://www.themoviedb.org/tv/209707
+    # tvdb: https://www.thetvdb.com/dereferrer/series/424435
+    seasons:
+      - season: 1
+        anilist-id: 154412
+      - season: 2
+        anilist-id: 166477
+  - title: "The Fruit of Grisaia"
+    guid: plex://show/5d9c0849ffd9ef001e990fe3
+    # imdb: https://www.imdb.com/title/tt3909210/
+    # tmdb: https://www.themoviedb.org/tv/61422
+    # tvdb: https://www.thetvdb.com/dereferrer/series/281949
+    seasons:
+      - season: 1
+        anilist-id: 17729
+      - season: 2
+        anilist-id: 21006
+  - title: "I Tried Asking While Kowtowing"
+    guid: plex://show/5f262b806880010040abc2cb
+    # imdb: https://www.imdb.com/title/tt12803708/
+    # tmdb: https://www.themoviedb.org/tv/106691
+    # tvdb: https://www.thetvdb.com/dereferrer/series/388536
+    seasons:
+      - season: 1
+        anilist-id: 122137
+  - title: "Jubei-chan the Ninja Girl: Secret of the Lovely Eyepatch"
+    guid: plex://show/61b16922bb2f1261dee5e5a0
+    # imdb: https://www.imdb.com/title/tt0192903/
+    # tmdb: https://www.themoviedb.org/tv/34723
+    # tvdb: https://www.thetvdb.com/dereferrer/series/73703
+    synonyms:
+     - 'Jubei-chan: The Ninja Girl'
+    seasons:
+      - season: 1
+        anilist-id: 635
+      - season: 2
+        anilist-id: 636
+  - title: "Nisekoi"
+    guid: plex://show/5d9c086702391c001f5886bd
+    # imdb: https://www.imdb.com/title/tt3115338/
+    # tmdb: https://www.themoviedb.org/tv/62640
+    # tvdb: https://www.thetvdb.com/dereferrer/series/275670
+    synonyms:
+     - 'Nisekoi: False Love'
+    seasons:
+      - season: 1
+        anilist-id: 18897
+      - season: 2
+        anilist-id: 20876
+  - title: "Saekano: How to Raise a Boring Girlfriend"
+    guid: plex://show/5d9c08142df347001e3aa27f
+    # imdb: https://www.imdb.com/title/tt3612626/
+    # tmdb: https://www.themoviedb.org/tv/69367
+    # tvdb: https://www.thetvdb.com/dereferrer/series/281275
+    seasons:
+      - season: 1
+        anilist-id: 20657
+      - season: 2
+        anilist-id: 21180
+  - title: "We Never Learn"
+    guid: plex://show/5d9c091808fddd001f2a7942
+    # imdb: https://www.imdb.com/title/tt9883676/
+    # tmdb: https://www.themoviedb.org/tv/87432
+    # tvdb: https://www.thetvdb.com/dereferrer/series/359095
+    synonyms:
+     - "We Never Learn: BOKUBEN"
+    seasons:
+      - season: 1
+        anilist-id: 103900
+      - season: 2
+        anilist-id: 110229

--- a/series-tvdb.en.yaml
+++ b/series-tvdb.en.yaml
@@ -3719,6 +3719,7 @@ entries:
         anilist-id: 180
       - season: 2
         anilist-id: 181
+        
   - title: "The Café Terrace and Its Goddesses"
     guid: plex://show/631a4e7b302708c9f85bd3dd
     # imdb: https://www.imdb.com/title/tt22087138/


### PR DESCRIPTION
Added titles:
"Ah! My Buddha"
"All Purpose Cultural Cat Girl Nuku Nuku (1998)"
"Burn-Up W"
"Charger Girl Juden Chan"
"Cross Ange: Rondo of Angels and Dragons"
"Divergence Eve"
"Eureka Seven"
"Freezing"
"Girls Bravo"
"Grenadier"
"Haganai: I Don't Have Many Friends"
"Ikki Tousen"
"Is This a Zombie?"
"The Melancholy of Haruhi Suzumiya"
"Queen's Blade"
"Ranma ½" (The 1989 version) Anilist changed their listing years ago, making "Season 1" 18 episodes, and then having the remaining 143 episodes in a second entry instead of 7 seasons, which is how it's picked up in plex (https://anilist.co/anime/210/Ranma-/ and https://anilist.co/anime/149939/Ranma--1989/ ) "Samurai Girls"
"School Rumble"
"Senran Kagura: Ninja Flash"
"The Testament of Sister New Devil"
"To LOVE-Ru"
"VanDread"
"The Café Terrace and Its Goddesses"
"The Fruit of Grisaia"
"I Tried Asking While Kowtowing"
"Jubei-chan the Ninja Girl: Secret of the Lovely Eyepatch" "Nisekoi"
"Saekano: How to Raise a Boring Girlfriend"
"We Never Learn"

These were all failing to match. Adding these solved the unmatched titles, so I figured I'd share. Some entries have season titles, which I added as comments for clarity. They don't seem to cause any issues, but can be removed if unwanted.