### PR TITLE
Add season 2-3 of The Apothecary Diaries

### DIFF
--- a/series-tmdb.en.yaml
+++ b/series-tmdb.en.yaml
@@ -3087,6 +3087,12 @@ entries:
     seasons:
       - season: 1
         anilist-id: 161645
+      - season: 1
+        anilist-id: 176301
+        start: 25
+      - season: 1
+        anilist-id: 195516
+        start: 49
 
   - title: "The Aristocrat's Otherworldly Adventure: Serving Gods Who Go Too Far"
     guid: plex://show/62ee806c7228b8684ca9dc5e

--- a/series-tvdb.en.yaml
+++ b/series-tvdb.en.yaml
@@ -3134,6 +3134,10 @@ entries:
     seasons:
       - season: 1
         anilist-id: 161645
+      - season: 2
+        anilist-id: 176301
+      - season: 3
+        anilist-id: 195516
 
   - title: "The Aristocrat’s Otherworldly Adventure: Serving Gods Who Go Too Far"
     guid: plex://show/62ee806c7228b8684ca9dc5e


### PR DESCRIPTION
Supersedes #125

The issue with #125 is that it introduces unnecessary comments that links to the AniList pages, as well as failing to also add Season 2 to the TMDB mapping. This PR ammends that as well as adds Season 3 with how it's projected to set on the respective websites.